### PR TITLE
Feature: manual history saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ const onMouseUp = () => {
 };
 ```
 
+### useRecoilHistory
+
+This hook returns object with `startHistorySaving()`, `stopHistorySaving()`, `getTotalPast()` and `getTotalFuture()` functions.
+
+````js
+
+const undo = useUndo();
+const {startHistorySaving, stopHistorySaving, getTotalPast, getTotalFuture} = useRecoilHistory();
+
+// default value = 23
+const [value, setValue] = useRecoilState(valueAtom);
+startHistorySaving();
+setValue({value: 1});
+stopHistorySaving();
+
+// getTotalPast() === 1
+
+setRecoilValue({value: 55});
+// getTotalPast() === 1
+undo();
+// getTotalPast() === 0
+// getTotalFuture() === 1
+// value === 23
+
+````
+
 ## Roadmap
 
 - Undo scoping (keep multiple undo stacks in a single application)

--- a/README.md
+++ b/README.md
@@ -109,18 +109,18 @@ const onMouseUp = () => {
 
 ### useRecoilHistory
 
-This hook returns object with `startHistorySaving()`, `stopHistorySaving()`, `getTotalPast()` and `getTotalFuture()` functions.
+This hook returns object with `startTrackingHistory()`, `stopTrackingHistory()`, `getIsTrackingHistory()`, `getTotalPast()` and `getTotalFuture()` functions.
 
 ````js
 
 const undo = useUndo();
-const {startHistorySaving, stopHistorySaving, getTotalPast, getTotalFuture} = useRecoilHistory();
+const {startTrackingHistory, stopTrackingHistory, getTotalPast, getTotalFuture, getIsTrackingHistory} = useRecoilHistory();
 
 // default value = 23
 const [value, setValue] = useRecoilState(valueAtom);
-startHistorySaving();
+startTrackingHistory();
 setValue({value: 1});
-stopHistorySaving();
+stopTrackingHistory();
 
 // getTotalPast() === 1
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -12,18 +12,25 @@ describe('recoil-undo', () => {
       getCountx2,
       typeText,
       getText,
+      getTotalPast,
+      getTotalFuture,
     } = renderCounter();
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(0);
     plus();
     expect(getCount()).toBe(1);
+    expect(getTotalPast()).toBe(1);
 
     plus();
     plus();
     minus();
     expect(getCount()).toBe(2);
+    expect(getTotalPast()).toBe(4);
     // It also works with selectors
     expect(getCountx2()).toBe(4);
 
     undo();
+    expect(getTotalPast()).toBe(3);
 
     expect(getCount()).toBe(3);
     expect(getCountx2()).toBe(6);
@@ -31,13 +38,16 @@ describe('recoil-undo', () => {
     redo();
     expect(getCount()).toBe(2);
     expect(getCountx2()).toBe(4);
+    expect(getTotalPast()).toBe(4);
 
     typeText('yeet');
     expect(getText()).toBe('yeet');
+    expect(getTotalPast()).toBe(5);
 
     undo();
     expect(getText()).toBe('');
     expect(getCount()).toBe(2);
+    expect(getTotalPast()).toBe(4);
   });
 
   it('only changes tracked atoms when undoing', () => {
@@ -83,7 +93,6 @@ describe('recoil-undo', () => {
     const {
       plus,
       minus,
-      redo,
       undo,
       getCount,
       startBatch,
@@ -109,5 +118,72 @@ describe('recoil-undo', () => {
     expect(getCount()).toBe(1);
     undo();
     expect(getCount()).toBe(0);
+  });
+
+  it('saves no history', () => {
+    const {
+      plus,
+      minus,
+      getCount,
+      getTotalPast,
+      getTotalFuture,
+    } = renderCounter({ manualHistory: true });
+
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(0);
+    plus();
+    expect(getCount()).toBe(1);
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(0);
+
+    plus();
+    plus();
+    minus();
+    expect(getCount()).toBe(2);
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(0);
+  });
+
+  it('saves history when chosen to', () => {
+    const {
+      plus,
+      minus,
+      undo,
+      getCount,
+      getTotalPast,
+      getTotalFuture,
+      startSavingHistory,
+      stopSavingHistory,
+    } = renderCounter({ manualHistory: true });
+
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(0);
+    startSavingHistory();
+    plus();
+    expect(getCount()).toBe(1);
+    expect(getTotalPast()).toBe(1);
+    expect(getTotalFuture()).toBe(0);
+    stopSavingHistory();
+
+    plus();
+    plus();
+    minus();
+    expect(getCount()).toBe(2);
+    expect(getTotalPast()).toBe(1);
+    expect(getTotalFuture()).toBe(0);
+
+    undo();
+    expect(getCount()).toBe(0);
+    expect(getTotalPast()).toBe(0);
+    expect(getTotalFuture()).toBe(1);
+
+    startSavingHistory();
+    plus();
+    plus();
+    plus();
+    expect(getCount()).toBe(3);
+    expect(getTotalPast()).toBe(2);
+    expect(getTotalFuture()).toBe(0);
+    stopSavingHistory();
   });
 });

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -152,18 +152,18 @@ describe('recoil-undo', () => {
       getCount,
       getTotalPast,
       getTotalFuture,
-      startSavingHistory,
-      stopSavingHistory,
+      startTrackingHistory,
+      stopTrackingHistory,
     } = renderCounter({ manualHistory: true });
 
     expect(getTotalPast()).toBe(0);
     expect(getTotalFuture()).toBe(0);
-    startSavingHistory();
+    startTrackingHistory();
     plus();
     expect(getCount()).toBe(1);
     expect(getTotalPast()).toBe(1);
     expect(getTotalFuture()).toBe(0);
-    stopSavingHistory();
+    stopTrackingHistory();
 
     plus();
     plus();
@@ -177,13 +177,13 @@ describe('recoil-undo', () => {
     expect(getTotalPast()).toBe(0);
     expect(getTotalFuture()).toBe(1);
 
-    startSavingHistory();
+    startTrackingHistory();
     plus();
     plus();
     plus();
     expect(getCount()).toBe(3);
     expect(getTotalPast()).toBe(2);
     expect(getTotalFuture()).toBe(0);
-    stopSavingHistory();
+    stopTrackingHistory();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,6 @@ type ContextState = {
   stopSavingHistory: () => void;
   getTotalPast: () => number;
   getTotalFuture: () => number;
-  getHistoryObject: () => any;
 };
 
 const UndoContext = React.createContext<ContextState>({
@@ -45,7 +44,6 @@ const UndoContext = React.createContext<ContextState>({
   stopSavingHistory: () => {},
   getTotalPast: () => 0,
   getTotalFuture: () => 0,
-  getHistoryObject: () => {},
 });
 
 type Props = {
@@ -195,8 +193,6 @@ export const RecoilUndoRoot = React.memo(
       return history.future.length;
     };
 
-    const getHistoryObject = () => history;
-
     const value = {
       undo,
       redo,
@@ -206,7 +202,6 @@ export const RecoilUndoRoot = React.memo(
       stopSavingHistory,
       getTotalPast,
       getTotalFuture,
-      getHistoryObject,
     };
 
     return (
@@ -284,14 +279,12 @@ export function useRecoilHistory() {
     stopSavingHistory,
     getTotalPast,
     getTotalFuture,
-    getHistoryObject,
   } = useContext(UndoContext);
   return {
     startSavingHistory,
     stopSavingHistory,
     getTotalPast,
     getTotalFuture,
-    getHistoryObject,
   };
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,9 @@ type ContextState = {
   redo: () => void;
   startBatch: () => void;
   endBatch: () => void;
-  startSavingHistory: () => void;
-  stopSavingHistory: () => void;
+  getIsTrackingHistory: () => boolean;
+  startTrackingHistory: () => void;
+  stopTrackingHistory: () => void;
   getTotalPast: () => number;
   getTotalFuture: () => number;
 };
@@ -40,8 +41,9 @@ const UndoContext = React.createContext<ContextState>({
   redo: () => {},
   startBatch: () => {},
   endBatch: () => {},
-  startSavingHistory: () => {},
-  stopSavingHistory: () => {},
+  getIsTrackingHistory: () => true,
+  startTrackingHistory: () => {},
+  stopTrackingHistory: () => {},
   getTotalPast: () => 0,
   getTotalFuture: () => 0,
 });
@@ -172,14 +174,18 @@ export const RecoilUndoRoot = React.memo(
       isBatchingRef.current = false;
     }, [isBatchingRef]);
 
-    const startSavingHistory = useCallback(() => {
+    const getIsTrackingHistory = useCallback((): boolean => {
+      return isUsingHistory.current;
+    }, [manualHistory, isUsingHistory.current]);
+
+    const startTrackingHistory = useCallback(() => {
       if (!manualHistory) {
         return;
       }
       isUsingHistory.current = true;
     }, [manualHistory]);
 
-    const stopSavingHistory = useCallback(() => {
+    const stopTrackingHistory = useCallback(() => {
       if (!manualHistory) {
         return;
       }
@@ -198,8 +204,9 @@ export const RecoilUndoRoot = React.memo(
       redo,
       startBatch,
       endBatch,
-      startSavingHistory,
-      stopSavingHistory,
+      getIsTrackingHistory,
+      startTrackingHistory,
+      stopTrackingHistory,
       getTotalPast,
       getTotalFuture,
     };
@@ -275,14 +282,16 @@ function didAtomMapsChange(prev: AtomMap, curr: AtomMap): boolean {
 
 export function useRecoilHistory() {
   const {
-    startSavingHistory,
-    stopSavingHistory,
+    getIsTrackingHistory,
+    startTrackingHistory,
+    stopTrackingHistory,
     getTotalPast,
     getTotalFuture,
   } = useContext(UndoContext);
   return {
-    startSavingHistory,
-    stopSavingHistory,
+    getIsTrackingHistory,
+    startTrackingHistory,
+    stopTrackingHistory,
     getTotalPast,
     getTotalFuture,
   };

--- a/src/test_utils/examples.tsx
+++ b/src/test_utils/examples.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { useUndo, useRedo, RecoilUndoRoot, useBatching } from '../index';
+import {
+  useUndo,
+  useRedo,
+  RecoilUndoRoot,
+  useBatching,
+  useRecoilHistory,
+} from '../index';
 import {
   RecoilRoot,
   atom,
@@ -26,8 +32,10 @@ const TEXT = atom({
   key: 'text',
 });
 
-type Props = { trackedAtoms?: RecoilState<any>[] };
-
+type Props = {
+  trackedAtoms?: RecoilState<any>[];
+  manualHistory?: boolean;
+};
 const App = (props: Props) => {
   return (
     <RecoilRoot>
@@ -45,6 +53,13 @@ function Counter() {
   const undo = useUndo();
   const redo = useRedo();
   const { startBatch, endBatch } = useBatching();
+  const {
+    startSavingHistory,
+    stopSavingHistory,
+    getTotalPast,
+    getTotalFuture,
+  } = useRecoilHistory();
+
   return (
     <div>
       <div>
@@ -80,6 +95,14 @@ function Counter() {
       <button data-testid='endBatch' onClick={endBatch}>
         End Batch
       </button>
+      <button data-testid='startSavingHistory' onClick={startSavingHistory}>
+        Start using history
+      </button>
+      <button data-testid='stopSavingHistory' onClick={stopSavingHistory}>
+        Stop using history
+      </button>
+      <div data-testid='totalPastValue'>{getTotalPast()}</div>
+      <div data-testid='totalFutureValue'>{getTotalFuture()}</div>
     </div>
   );
 }
@@ -95,6 +118,10 @@ export function renderCounter(props: Props = {}) {
   const text = queries.getByTestId('text') as HTMLInputElement;
   const startBatchButton = queries.getByTestId('startBatch');
   const endBatchButton = queries.getByTestId('endBatch');
+  const startSavingHistoryButton = queries.getByTestId('startSavingHistory');
+  const stopSavingHistoryButton = queries.getByTestId('stopSavingHistory');
+  const getTotalPastValue = queries.getByTestId('totalPastValue');
+  const getTotalFutureValue = queries.getByTestId('totalFutureValue');
 
   const plus = () => fireEvent.click(inc);
   const minus = () => fireEvent.click(dec);
@@ -107,6 +134,10 @@ export function renderCounter(props: Props = {}) {
     fireEvent.change(text, { target: { value } });
   const startBatch = () => fireEvent.click(startBatchButton);
   const endBatch = () => fireEvent.click(endBatchButton);
+  const startSavingHistory = () => fireEvent.click(startSavingHistoryButton);
+  const stopSavingHistory = () => fireEvent.click(stopSavingHistoryButton);
+  const getTotalPast = () => Number(getTotalPastValue.textContent);
+  const getTotalFuture = () => Number(getTotalFutureValue.textContent);
 
   return {
     plus,
@@ -120,5 +151,9 @@ export function renderCounter(props: Props = {}) {
     startBatch,
     endBatch,
     queries,
+    startSavingHistory,
+    stopSavingHistory,
+    getTotalPast,
+    getTotalFuture,
   };
 }

--- a/src/test_utils/examples.tsx
+++ b/src/test_utils/examples.tsx
@@ -54,8 +54,8 @@ function Counter() {
   const redo = useRedo();
   const { startBatch, endBatch } = useBatching();
   const {
-    startSavingHistory,
-    stopSavingHistory,
+    startTrackingHistory,
+    stopTrackingHistory,
     getTotalPast,
     getTotalFuture,
   } = useRecoilHistory();
@@ -95,10 +95,10 @@ function Counter() {
       <button data-testid='endBatch' onClick={endBatch}>
         End Batch
       </button>
-      <button data-testid='startSavingHistory' onClick={startSavingHistory}>
+      <button data-testid='startTrackingHistory' onClick={startTrackingHistory}>
         Start using history
       </button>
-      <button data-testid='stopSavingHistory' onClick={stopSavingHistory}>
+      <button data-testid='stopTrackingHistory' onClick={stopTrackingHistory}>
         Stop using history
       </button>
       <div data-testid='totalPastValue'>{getTotalPast()}</div>
@@ -118,8 +118,10 @@ export function renderCounter(props: Props = {}) {
   const text = queries.getByTestId('text') as HTMLInputElement;
   const startBatchButton = queries.getByTestId('startBatch');
   const endBatchButton = queries.getByTestId('endBatch');
-  const startSavingHistoryButton = queries.getByTestId('startSavingHistory');
-  const stopSavingHistoryButton = queries.getByTestId('stopSavingHistory');
+  const startTrackingHistoryButton = queries.getByTestId(
+    'startTrackingHistory',
+  );
+  const stopTrackingHistoryButton = queries.getByTestId('stopTrackingHistory');
   const getTotalPastValue = queries.getByTestId('totalPastValue');
   const getTotalFutureValue = queries.getByTestId('totalFutureValue');
 
@@ -134,8 +136,9 @@ export function renderCounter(props: Props = {}) {
     fireEvent.change(text, { target: { value } });
   const startBatch = () => fireEvent.click(startBatchButton);
   const endBatch = () => fireEvent.click(endBatchButton);
-  const startSavingHistory = () => fireEvent.click(startSavingHistoryButton);
-  const stopSavingHistory = () => fireEvent.click(stopSavingHistoryButton);
+  const startTrackingHistory = () =>
+    fireEvent.click(startTrackingHistoryButton);
+  const stopTrackingHistory = () => fireEvent.click(stopTrackingHistoryButton);
   const getTotalPast = () => Number(getTotalPastValue.textContent);
   const getTotalFuture = () => Number(getTotalFutureValue.textContent);
 
@@ -151,8 +154,8 @@ export function renderCounter(props: Props = {}) {
     startBatch,
     endBatch,
     queries,
-    startSavingHistory,
-    stopSavingHistory,
+    startTrackingHistory,
+    stopTrackingHistory,
     getTotalPast,
     getTotalFuture,
   };


### PR DESCRIPTION
## Issue
Sometimes I do not want for state change to be written into history.

## Solution
Introduce `manualHistory` prop on `RecoilUndoRoot`, introduce `useRecoilHistory` hook which exposes `startSavingHistory()`, `stopSavingHistory()`, `getTotalPast()` and `getTotalFuture()`.